### PR TITLE
Adds business_url to DB query, to get it to show in the letters API

### DIFF
--- a/lib/BuyLocal/Schema/ResultSet/Letter.pm
+++ b/lib/BuyLocal/Schema/ResultSet/Letter.pm
@@ -26,7 +26,7 @@ sub get_letters {
             date_created => { '<=' => $dtf->format_datetime($now) }, # Don't return items from the future! :)
         },
         {   
-            columns => [qw/id first_name last_name business_name business_city date_created public_name letter_text/],
+            columns => [qw/id first_name last_name business_name business_url business_city date_created public_name letter_text/],
             page => $page || 1,     # page to return (default: 1)
             rows => $limit || 20,    # number of results per page (default: 20)
             order_by =>  { -desc => 'date_created' },


### PR DESCRIPTION
This adds business_url to DB query, to get it to return the biz website in the API json for letters. 

(This may be an incomplete change, but I'm pretty sure this is all that's missing.) 
